### PR TITLE
pass along the second (and all other params) to yarp,

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+coverage/lcov-report/*

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: "vinli/server"

--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ const onError = function(err) {
   }
 };
 
-module.exports = function(options) {
-  return yarp(options).catch(onError);
+module.exports = function(...options) {
+  return yarp(...options).catch(onError);
 };

--- a/package.json
+++ b/package.json
@@ -4,9 +4,14 @@
   "description": "Throw Boom objects when your Yarps fail.",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint . --fix",
     "test": "mocha --recursive -R spec",
+    "posttest": "eslint .",
     "test-cov": "istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vinli/yarp-boom.git"
@@ -18,16 +23,18 @@
   },
   "homepage": "https://github.com/vinli/yarp-boom#readme",
   "dependencies": {
-    "boom": "^3.1.1",
+    "boom": ">3",
     "yarp": "^0.4.5"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "eslint": "^0.22.1",
-    "eslint-config-vinli": "^2.0.3",
-    "istanbul": "^0.4.2",
-    "mocha": "^2.3.4",
-    "nock": "^5.2.1"
+    "chai": "^3.5.0",
+    "eslint": "^3.3.1",
+    "eslint-config-vinli": "^5.1.2",
+    "eslint-plugin-mocha": "^4.4.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.0.2",
+    "nock": "^8.0.0",
+    "pre-commit": "^1.1.3"
   },
   "directories": {
     "test": "test"

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: "vinli/server/tests"

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,22 @@ describe('yarp-boom', () => {
       });
   });
 
+  it('should pass along the second param to yarp', () => {
+    const m = nock('http://some.domain')
+      .get('/some/url')
+      .reply(400, { foo: 'bar' });
+
+    return yarpBoom('http://some.domain/some/url', true)
+      .then((resp) => {
+        expect(resp).to.have.property('statusCode', 400);
+        expect(resp).to.have.property('data');
+        expect(resp.data).to.be.deep.equal({ foo: 'bar' });
+      })
+      .finally(() => {
+        m.done();
+      });
+  });
+
   it('should return a boom object for a 4xx level error', () => {
     const m = nock('http://some.domain')
       .get('/some/url')


### PR DESCRIPTION
Also more permissive boom versioning